### PR TITLE
Initialize AutoPkg overrides repo

### DIFF
--- a/.github/workflows/verify-trust.yml
+++ b/.github/workflows/verify-trust.yml
@@ -1,0 +1,34 @@
+name: Verify AutoPkg trust
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  verify:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup AutoPkg
+        uses: autopkg/setup-autopkg-actions@v1
+
+      - name: Add upstream recipe repos
+        run: |
+          set -euo pipefail
+          autopkg repo-add https://github.com/autopkg/recipes || true
+          autopkg repo-add https://github.com/homebysix/recipes || true
+          autopkg repo-add https://github.com/homebysix/stopthescripts || true
+          autopkg repo-list
+
+      - name: Verify trust for all overrides (if any)
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          failures=0
+          for f in overrides/*.recipe overrides/*.recipe.yaml; do
+            echo "Verifying trust: $f"
+            if ! autopkg verify-trust-info "$f"; then
+              echo "::error ::Trust verification failed for $f"
+              failures=1
+            fi
+          done
+          exit $failures

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# local artifacts
+*.DS_Store
+*.swp
+.idea/
+.vscode/
+out/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,60 @@
 # autopkg-overrides
+
+Source-of-truth for AutoPkg **override files** and **trust info**, plus environment recipe lists.
+
+- **No secrets** live here. This repo should be safe to make public.
+- The **runner** repo consumes this as read-only, runs AutoPkg, uploads to Fleet, and opens PRs in `fleet-gitops`.
+
+## Structure
+
+
+recipe-lists/ # plain text lists of recipe names to run
+darwin-prod.txt
+overrides/ # your *.recipe or *.recipe.yaml overrides (with embedded trust)
+.keep
+scripts/ # local helper scripts (no CI secrets)
+add_override.sh
+docs/
+ADD_OVERRIDE.md
+
+
+## Quick start
+1. Install AutoPkg locally: `brew install autopkg`
+2. Add upstream recipe repos (one-time):
+   ```bash
+   autopkg repo-add https://github.com/autopkg/recipes
+   autopkg repo-add https://github.com/homebysix/recipes
+   autopkg repo-list
+   ```
+
+Add an override (example: Firefox.pkg):
+
+./scripts/add_override.sh Firefox.pkg
+
+
+This generates overrides/Firefox.pkg.recipe and embeds ParentRecipeTrustInfo.
+
+Add the recipe name to a list (e.g., recipe-lists/darwin-prod.txt).
+
+Commit + open PR. The runner repo will verify trust before building.
+
+Trust model
+
+We embed trust in each override file (field: ParentRecipeTrustInfo).
+
+CI in this repo (verify-trust.yml) verifies only the overrides present.
+
+If upstream recipes change, verify-trust fails; update trust with:
+
+autopkg update-trust-info overrides/<Name>.recipe
+
+
+Prefer minimal overrides (only inputs you actually need).
+
+Conventions
+
+Override filenames mirror the recipe name: Firefox.pkg.recipe, Slack.pkg.recipe.
+
+Use .recipe (plist/XML) or .recipe.yaml—pick one and be consistent.
+
+Keep recipe-lists/* deterministic; comments start with #.

--- a/docs/ADD_OVERRIDE.md
+++ b/docs/ADD_OVERRIDE.md
@@ -1,0 +1,32 @@
+# Add a new override
+
+1) Make sure you’ve added upstream recipe repos locally:
+```bash
+autopkg repo-add https://github.com/autopkg/recipes
+autopkg repo-add https://github.com/homebysix/recipes
+```
+
+Generate the override and embed trust:
+
+```bash
+./scripts/add_override.sh Firefox.pkg
+# creates overrides/Firefox.pkg.recipe with ParentRecipe + ParentRecipeTrustInfo
+```
+
+(Optional) Tweak inputs in the override (e.g., NAME, DOWNLOAD_URL, etc.).
+
+Add the recipe name to a list (e.g., recipe-lists/darwin-prod.txt):
+
+```
+Firefox.pkg
+```
+
+Commit and open a PR. CI will run Verify AutoPkg trust.
+
+Tips
+
+To inspect an override: `autopkg info overrides/Firefox.pkg.recipe`
+
+To refresh trust after upstream changes: `autopkg update-trust-info overrides/Firefox.pkg.recipe`
+
+Keep overrides minimal; prefer letting upstream recipes evolve.

--- a/recipe-lists/darwin-prod.txt
+++ b/recipe-lists/darwin-prod.txt
@@ -1,0 +1,5 @@
+# One recipe name per line. These must resolve via your added recipe repos.
+# Examples:
+Firefox.pkg
+# Slack.pkg
+# Zoom.pkg

--- a/scripts/add_override.sh
+++ b/scripts/add_override.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ $# -lt 1 ]]; then
+  echo "usage: $0 <RecipeName> [<RecipeName> ...]" >&2
+  exit 2
+fi
+
+# Ensure upstream repos exist
+autopkg repo-list >/dev/null || {
+  echo "AutoPkg not initialized. Run 'autopkg repo-add …' first." >&2
+  exit 1
+}
+
+mkdir -p overrides
+for r in "$@"; do
+  base="${r##*/}"
+  out="overrides/${base}.recipe"
+  # If a YAML override is preferred, change extension and add --format=yaml once supported in make-override.
+  echo "Creating override: $out"
+  autopkg make-override "$r" -o "$out"
+  echo "Embedding trust info: $out"
+  autopkg update-trust-info "$out"
+  echo "OK: $out"
+done


### PR DESCRIPTION
## Summary
- add repository structure, scripts, and docs for AutoPkg overrides
- automate trust verification via GitHub Actions

## Testing
- `bash -n scripts/add_override.sh`


------
https://chatgpt.com/codex/tasks/task_e_68bdce6048b8832189c3e5c35bded406